### PR TITLE
Switch wmic to powershell command

### DIFF
--- a/hwid/core.py
+++ b/hwid/core.py
@@ -19,10 +19,9 @@ def get_hwid():
         output = subprocess.check_output(command, shell=True)
         output = output.decode("utf-8").strip()
     elif platform in ["win32"]:
-        command = "wmic csproduct get uuid"
+        command = 'powershell -Command "(Get-CimInstance -ClassName Win32_ComputerSystemProduct).UUID"'
         output = subprocess.check_output(command, shell=True)
         output = output.decode("utf-8").strip()
-        output = output.split("\n")[1].strip()
     elif platform in ["darwin"]:
         command = "system_profiler SPHardwareDataType | grep 'UUID'"
         output = subprocess.check_output(command, shell=True)


### PR DESCRIPTION
Replace direct WMIC call with a PowerShell method for better compatibility on modern Windows versions where WMIC may be deprecated or unavailable.