### PR TITLE
Add Android support for HWID extraction

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,33 @@
+name: Android CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          pip3 install jnius
+
+      - name: Run tests
+        run: |
+          python3 -m unittest discover -s tests

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Downloads/Month](https://pepy.tech/badge/hwid/month)](https://pepy.tech/project/hwid)
 [![Downloads/Week](https://pepy.tech/badge/hwid/week)](https://pepy.tech/project/hwid)
 
-Extract the `hwid` on Windows, Linux, Mac. Cross-platform using Python, native OS detection.
+Extract the `hwid` on Windows, Linux, Mac, Android. Cross-platform using Python, native OS detection.
 
 ---
 
@@ -48,6 +48,14 @@ CLI:
 ```bash
 hwid
 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+```
+
+Android:
+
+```python
+import hwid
+print(hwid.get_hwid())
+# 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
 ```
 
 ## Motivation

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 [![Downloads/Month](https://pepy.tech/badge/hwid/month)](https://pepy.tech/project/hwid)
 [![Downloads/Week](https://pepy.tech/badge/hwid/week)](https://pepy.tech/project/hwid)
 
-Extract the `hwid` on Windows, Linux, Mac. Cross-platform using Python, native OS detection.
+Extract the `hwid` on Windows, Linux, Mac, Android. Cross-platform using Python, native OS detection.
 
 ---
 
@@ -48,6 +48,14 @@ CLI:
 ```bash
 hwid
 XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+```
+
+Android:
+
+```python
+import hwid
+print(hwid.get_hwid())
+# 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
 ```
 
 ## Motivation

--- a/hwid/core.py
+++ b/hwid/core.py
@@ -4,13 +4,21 @@ from sys import platform
 
 from .exceptions import InvalidHWID, UnsupportedOS
 
+def get_android_hwid():
+    try:
+        import jnius
+        from jnius import autoclass
+
+        Build = autoclass('android.os.Build')
+        return Build.SERIAL
+    except ImportError:
+        raise UnsupportedOS("Unsupported OS: Android support requires Pyjnius")
 
 def validate_hwid(hwid):
     if re.match(r"^[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}$", hwid):
         return True
     else:
         return False
-
 
 def get_hwid():
     """Gets the HWID."""
@@ -28,6 +36,8 @@ def get_hwid():
         output = subprocess.check_output(command, shell=True)
         output = output.decode("utf-8").strip()
         output = output.split(":")[1].strip()
+    elif platform == "android":
+        output = get_android_hwid()
     else:
         raise UnsupportedOS("Unsupported OS")
     if validate_hwid(output):

--- a/hwid/core.py
+++ b/hwid/core.py
@@ -4,21 +4,24 @@ from sys import platform
 
 from .exceptions import InvalidHWID, UnsupportedOS
 
+
 def get_android_hwid():
     try:
         import jnius
         from jnius import autoclass
 
-        Build = autoclass('android.os.Build')
+        Build = autoclass("android.os.Build")
         return Build.SERIAL
     except ImportError:
         raise UnsupportedOS("Unsupported OS: Android support requires Pyjnius")
+
 
 def validate_hwid(hwid):
     if re.match(r"^[a-fA-F0-9]{8}-([a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12}$", hwid):
         return True
     else:
         return False
+
 
 def get_hwid():
     """Gets the HWID."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ hwid = "hwid.__main__:app"
 
 [tool.poetry.dependencies]
 python = ">=3.0,<4.0"
+jnius = { version = "*", markers = "sys_platform == 'android'" }
 
 
 [tool.ruff]


### PR DESCRIPTION
This pull request introduces Android support for the `hwid` library, enabling hardware ID extraction on Android devices. It includes updates to the codebase, documentation, and CI workflow to integrate and test this new functionality.

### Android Support Integration:

* **Added Android HWID Extraction Logic**: Implemented a new function `get_android_hwid()` in `hwid/core.py` to retrieve the hardware ID on Android using the Pyjnius library. Updated the `get_hwid()` function to handle the Android platform. [[1]](diffhunk://#diff-ef5bdb3f6da57e0a922223d1e8b36ae762fc9b8be05effe9b36eec9c6a2db83cR7-L14) [[2]](diffhunk://#diff-ef5bdb3f6da57e0a922223d1e8b36ae762fc9b8be05effe9b36eec9c6a2db83cR39-R40)
* **Dependency Management**: Added `jnius` as a dependency in `pyproject.toml`, conditional on the Android platform.

### CI Workflow Updates:

* **New Android CI Workflow**: Created a `.github/workflows/android-ci.yml` file to automate testing on Android. This includes setting up the environment, installing dependencies, and running tests.

### Documentation Updates:

* **README and Docs Updates**: Updated `README.md` and `docs/index.md` to reflect Android support, including usage examples for extracting the hardware ID on Android. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R60)
