### PR TITLE
feat(ci): add PR title linting workflow to enforce Conventional Commits

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,39 @@
+---
+name: Lint PR
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Lint PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: marocchino/sticky-pull-request-comment@v2.9.0
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to validate pull request titles against the Conventional Commits specification, providing feedback through sticky comments for non-compliant titles.

New Features:
- Enforce Conventional Commit-style pull request titles via a new CI workflow

CI:
- Add a GitHub Actions workflow triggered on pull_request_target events to validate PR titles using amannn/action-semantic-pull-request
- Post or update a sticky comment with error details when the title fails linting
- Automatically remove the error comment when the PR title is corrected