### PR TITLE
feat: add Release Drafter configuration and workflow for automated release management

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -118,4 +118,3 @@ categories:
     labels:
       - other
       - chore
-

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/release-drafter/release-drafter/refs/heads/master/schema.json
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
+template: |
+  # :mega: hwid $RESOLVED_VERSION released!
+
+  We are pleased to announce the release of hwid $RESOLVED_VERSION.
+
+  ## :green_book: What's Changed
+
+  $CHANGES
+
+  ## :bow: Credits
+
+  Special thanks to the following contributors who helped with this release: $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: '- No changes'
+exclude-contributors:
+  - 'dependabot'
+  - 'pre-commit-ci'
+  - 'renovate'
+exclude-labels:
+  - 'skip-changelog'
+  - 'invalid'
+replacers:
+  # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
+  - search: '/(?:and )?@(pre-commit-ci|dependabot|renovate)(?:\[bot\])?,?/g'
+    replace: ''
+autolabeler:
+  - label: 'metadata'
+    files:
+      - 'README.md'
+      - 'pyproject.toml'
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/^fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    title:
+      - '/^feat/i'
+  - label: 'dependencies'
+    title:
+      - '/^chore\(deps\)/i'
+      - '/^fix\(deps\)/i'
+      - '/^chore:\s*bump/i'
+  - label: 'github_actions'
+    files:
+      - '.github/workflows/*.yml'
+  - label: 'chore'
+    title:
+      - '/^chore/i'
+prerelease-identifier: 'rc'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'metadata'
+      - 'maintenance'
+      - 'bug'
+      - 'dependencies'
+      - 'security'
+  default: patch
+categories:
+  - title: ':boom: Breaking'
+    labels:
+      - breaking
+  - title: ':rocket: Features'
+    labels:
+      - feature
+      - enhancement
+  - title: ':beetle: Bug Fixes'
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: ':toolbox: Maintenance'
+    labels:
+      - maintenance
+  - title: ':memo: Documentation'
+    labels:
+      - docs
+      - documentation
+  - title: ':package: Dependencies'
+    collapse-after: 5
+    labels:
+      - dependencies
+  - title: ':lock: Security'
+    labels:
+      - security
+  - title: ':construction_worker: Continuous Integration'
+    labels:
+      - ci
+      - github_actions
+  - title: ':wrench: Other changes'
+    labels:
+      - other
+      - chore
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+---
+name: Release Drafter
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+permissions:
+  contents: read
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write  # IMPORTANT: Mandatory for Release Drafter (release-drafter)
+      pull-requests: write  # IMPORTANT: Mandatory for Release Drafter (release-drafter)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft a Release
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hwid
 
+[![CI](https://github.com/hasansezertasan/hwid/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hasansezertasan/hwid/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/hasansezertasan/hwid)](https://codecov.io/gh/hasansezertasan/hwid)
 [![PyPI - Version](https://img.shields.io/pypi/v/hwid.svg)](https://pypi.org/project/hwid)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hwid.svg)](https://pypi.org/project/hwid)


### PR DESCRIPTION
## Summary by Sourcery

Set up automated release management by configuring Release Drafter, adding a corresponding GitHub Actions workflow, and updating the project README with a CI status badge.

New Features:
- Add Release Drafter configuration file for automated changelog and release drafting

CI:
- Add GitHub Actions workflow to draft releases on pushes to main/master and pull request events

Documentation:
- Add CI status badge to the README