### PR TITLE
feat: enable prerelease configuration with identifier for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,6 +31,8 @@ replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
   - search: '/(?:and )?@(pre-commit-ci|dependabot|renovate)(?:\[bot\])?,?/g'
     replace: ''
+prerelease: true
+prerelease-identifier: 'rc'
 autolabeler:
   - label: 'metadata'
     files:


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Enable prerelease mode with 'rc' identifier in Release Drafter configuration