### PR TITLE
refactor: remove prerelease identifier from Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,6 +31,8 @@ replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
   - search: '/(?:and )?@(pre-commit-ci|dependabot|renovate)(?:\[bot\])?,?/g'
     replace: ''
+prerelease: true
+prerelease-identifier: 'rc'
 autolabeler:
   - label: 'metadata'
     files:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -65,7 +65,6 @@ autolabeler:
   - label: 'chore'
     title:
       - '/^chore/i'
-prerelease-identifier: 'rc'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
- **feat: enable prerelease configuration with identifier for release drafter**
- **refactor: remove prerelease identifier from Release Drafter configuration**

## Summary by Sourcery

Enable prerelease in Release Drafter and consolidate prerelease identifier at the top level

Enhancements:
- Enable prerelease releases in the Release Drafter configuration
- Move the prerelease identifier to the root scope and remove the redundant nested entry