### PR TITLE
fix: update change-template format for clarity in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,7 +16,7 @@ template: |
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
-change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-template: '- $TITLE by @$AUTHOR in (#$NUMBER)'
 no-changes-template: '- No changes'
 exclude-contributors:
   - 'dependabot'


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust change-template to '- $TITLE by @$AUTHOR in (#$NUMBER)' for clearer attribution in release notes