### PR TITLE
ci(release-drafter): disable prerelease

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,8 +29,6 @@ replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
   - search: '/(?:and )?@(pre-commit-ci|dependabot|renovate)(?:\[bot\])?,?/g'
     replace: ''
-prerelease: true
-prerelease-identifier: 'rc'
 autolabeler:
   - label: 'metadata'
     files:


### PR DESCRIPTION
## Summary by Sourcery

Disable prereleases in Release Drafter by removing the prerelease flag and identifier from its configuration

CI:
- Remove prerelease: true setting from .github/release-drafter.yml
- Remove prerelease-identifier 'rc' from Release Drafter config