### PR TITLE
chore(renovate): adopt shared python preset config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "extends": [
-    "config:recommended"
-  ],
-  "labels": ["dependencies"],
-  "semanticCommits": "enabled"
+  "extends": ["github>hasansezertasan/renovate-config:python"]
 }


### PR DESCRIPTION
## What

Standardizes this repo's Renovate config on the shared preset [`github>hasansezertasan/renovate-config:python`](https://github.com/hasansezertasan/renovate-config), matching the setup used in `litestar-faststream` and other sibling repos.

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>hasansezertasan/renovate-config:python"]
}
```

## Why

Centralizes Renovate configuration in one maintained preset so this repo inherits future improvements automatically, rather than duplicating settings inline.

## What the `:python` preset provides

- `config:recommended` baseline
- `internal` label on update PRs
- `semanticCommits` enabled
- dependency dashboard
- scheduled `lockFileMaintenance` (before 4am Monday)
- `packageRules` grouping dev/test/lint/docs dep-groups and non-major runtime updates to reduce PR noise
- a custom manager for `rev` pins in `prek.toml`